### PR TITLE
Use github.com/zalando/go-keyring to reduce need for c libs

### DIFF
--- a/chrome_darwin.go
+++ b/chrome_darwin.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	keychain "github.com/keybase/go-keychain"
+	"github.com/zalando/go-keyring"
 )
 
 // Thanks to https://gist.github.com/dacort/bd6a5116224c594b14db.
@@ -36,11 +36,11 @@ func setChromeKeychainPassword(password []byte) []byte {
 // caching it for future calls.
 func getKeychainPassword() ([]byte, error) {
 	if keychainPassword == nil {
-		password, err := keychain.GetGenericPassword("Chrome Safe Storage", "Chrome", "", "")
+		password, err := keyring.Get("Chrome Safe Storage", "Chrome")
 		if err != nil {
 			return nil, fmt.Errorf("error reading 'Chrome Safe Storage' keychain password: %v", err)
 		}
-		keychainPassword = password
+		keychainPassword = []byte(password)
 	}
 	return keychainPassword, nil
 }


### PR DESCRIPTION
Using this lib which forks to use system tools vs using APIs. It's gross, but makes it slightly easier to cross compile by reducing the runtime dependency on system libs for darwin.