### PR TITLE
Chrome 80 windows - add AES decryption

### DIFF
--- a/chrome_windows.go
+++ b/chrome_windows.go
@@ -2,8 +2,17 @@ package kooky
 
 // https://groups.google.com/d/msg/golang-nuts/bUetmxErnTw/GHC5obCcmTMJ
 // https://play.golang.org/p/fknP9AuLU-
+// https://stackoverflow.com/a/60423699
 
 import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -42,6 +51,19 @@ func (b *data_blob) toByteArray() []byte {
 }
 
 func decrypt(data []byte) ([]byte, error) {
+	// present before Chrome 80
+	// 0x01000000D08C9DDF0115D1118C7A00C04FC297EB
+	var prefixDPAPI = []byte{1, 0, 0, 0, 208, 140, 157, 223, 1, 21, 209, 17, 140, 122, 0, 192, 79, 194, 151, 235}
+	if bytes.HasPrefix(data, prefixDPAPI) {
+		return decryptDPAPI(data)
+	} else if bytes.HasPrefix(data, []byte(`v10`)) {
+		return decryptAES256GCM(data)
+	} else {
+		return nil, errors.New(`unknown encryption`)
+	}
+}
+
+func decryptDPAPI(data []byte) ([]byte, error) {
 	var outblob data_blob
 	r, _, err := procDecryptData.Call(uintptr(unsafe.Pointer(newBlob(data))), 0, 0, 0, 0, CRYPTPROTECT_UI_FORBIDDEN, uintptr(unsafe.Pointer(&outblob)))
 	if r == 0 {
@@ -49,6 +71,45 @@ func decrypt(data []byte) ([]byte, error) {
 	}
 	defer procLocalFree.Call(uintptr(unsafe.Pointer(outblob.pbData)))
 	return outblob.toByteArray(), nil
+}
+
+func decryptAES256GCM(data []byte) ([]byte, error) {
+	// https://stackoverflow.com/a/60423699
+
+	if len(data) < 3+12+16 {
+		return nil, errors.New(`encrypted value too short`)
+	}
+
+	/* encoded value consists of: {
+		"v10" (3 bytes)
+		nonce (12 bytes)
+		ciphertext (variable size)
+		tag (16 bytes)
+	}
+	*/
+	nonce := data[3 : 3+12]
+	ciphertextWithTag := data[3+12:]
+
+	if err := getMasterKey(); err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// default size for nonce and tag match
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertextWithTag, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
 }
 
 func decryptValue(encrypted []byte) (string, error) {
@@ -61,4 +122,50 @@ func decryptValue(encrypted []byte) (string, error) {
 
 func setChromeKeychainPassword(password []byte) []byte {
 	return password
+}
+
+var masterKey []byte // TODO (?)
+
+func getMasterKey() error {
+	// this master key is used globally for all Chrome profiles
+	if len(masterKey) > 0 {
+		return nil // already set
+	}
+
+	// the "Local State" json file is normally one directory above the "Cookies" database
+	stateFile := filepath.Join(filepath.Dir(filepath.Dir(dbFile)), `Local State`)
+
+	stateBytes, err := ioutil.ReadFile(stateFile)
+	if err != nil {
+		return err
+	}
+
+	var localState struct {
+		OsCrypt struct {
+			EncryptedKey string `json:"encrypted_key"`
+		} `json:"os_crypt"`
+	}
+	if err := json.Unmarshal(stateBytes, &localState); err != nil {
+		return err
+	}
+
+	key, err := base64.StdEncoding.DecodeString(localState.OsCrypt.EncryptedKey)
+	if err != nil {
+		return err
+	}
+
+	if len(key) < 5 || !bytes.HasPrefix(key, []byte(`DPAPI`)) {
+		return errors.New(`not an DPAPI key`)
+	}
+	key = key[5:] // strip "DPAPI"
+	key, err = decryptDPAPI(key)
+	if err != nil {
+		return err
+	}
+	if len(key) != 32 {
+		return errors.New(`master key is not 32 bytes long`)
+	}
+	masterKey = key
+
+	return nil
 }


### PR DESCRIPTION
This PR adds support for the AES-256 GCM encryption introduced with Chrome 80 on Windows.
Chrome encrypts cookie values via AES with a master key. This master key is stored encrypted in the json file 'Local State' ".os_crypt.encrypted_key". For the decryption we can use Windows "CryptUnprotectData()" function which we already used in prior Chrome versions on Windows.

The "Local State" file should normally be one directory layer above the "Cookies" database in the profile folder. For the retrieval of the master key we need to know the location of the database to derive the json file location. For that reason there are now 2 global variables, it would be better to remodel the code a bit so that they are no longer necessary.

implementation was done by following https://stackoverflow.com/a/60423699 .

This PR fixes #12 .