### PR TITLE
Don't use row length checks or hardcoded column numbers with SQLite

### DIFF
--- a/internal/firefox/firefox.go
+++ b/internal/firefox/firefox.go
@@ -23,7 +23,7 @@ func (s *CookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.Cookie, err
 
 	var cookies []*kooky.Cookie
 
-	err := utils.VisitTableRows(s.Database, `moz_cookies`, func(rowId *int64, row utils.TableRow) error {
+	err := utils.VisitTableRows(s.Database, `moz_cookies`, map[string]string{}, func(rowId *int64, row utils.TableRow) error {
 		/*
 			-- Firefox 78 ESR - copied from sqlitebrowser
 			CREATE TABLE moz_cookies(
@@ -97,16 +97,14 @@ func (s *CookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.Cookie, err
 		}
 
 		// Secure
-		if isSecure, err := row.Int(`isSecure`); err == nil {
-			cookie.Secure = isSecure > 0
-		} else {
+		cookie.Secure, err = row.Bool(`isSecure`)
+		if err != nil {
 			return err
 		}
 
 		// HttpOnly
-		if isHttpOnly, err := row.Int(`isHttpOnly`); err == nil {
-			cookie.HttpOnly = isHttpOnly > 0
-		} else {
+		cookie.HttpOnly, err = row.Bool(`isHttpOnly`)
+		if err != nil {
 			return err
 		}
 

--- a/internal/firefox/firefox.go
+++ b/internal/firefox/firefox.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/zellyn/kooky"
+	"github.com/zellyn/kooky/internal/utils"
 
 	"github.com/bobesa/go-domain-util/domainutil"
-	"github.com/go-sqlite/sqlite3"
 )
 
 func (s *CookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.Cookie, error) {
@@ -23,55 +23,7 @@ func (s *CookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.Cookie, err
 
 	var cookies []*kooky.Cookie
 
-	var baseDomainRemoved bool = true
-	var columnIDs = map[string]int{
-		// fallback values
-		`baseDomain`:   1, // old
-		`name`:         2,
-		`value`:        3,
-		`host`:         4,
-		`path`:         5,
-		`expiry`:       6,
-		`creationTime`: 8,
-		`isSecure`:     9,
-		`isHttpOnly`:   10,
-	}
-	cookiesTableName := `moz_cookies`
-	var highestIndex int
-	for _, table := range s.Database.Tables() {
-		if table.Name() == cookiesTableName {
-			for id, column := range table.Columns() {
-				name := column.Name()
-				if name == `CONSTRAINT` {
-					// github.com/go-sqlite/sqlite3.Table.Columns() reports pseudo-columns for host, path, originAttributes
-					break
-				}
-				if name == `baseDomain` {
-					baseDomainRemoved = false
-				}
-				if id > highestIndex {
-					highestIndex = id
-				}
-				columnIDs[name] = id
-			}
-		}
-	}
-
-	err := s.Database.VisitTableRecords(cookiesTableName, func(rowId *int64, rec sqlite3.Record) error {
-		/*
-		   known column counts for firefox from past/current versions
-		   ???:     13 columns
-		   v78 LTS: 14 columns
-		   v82:     15 columns
-		*/
-
-		if highestIndex >= len(rec.Values) {
-			return errors.New(`column index out of bound`)
-		}
-
-		cookie := kooky.Cookie{}
-		var ok bool
-
+	err := utils.VisitTableRows(s.Database, `moz_cookies`, func(rowId *int64, row utils.TableRow) error {
 		/*
 			-- Firefox 78 ESR - copied from sqlitebrowser
 			CREATE TABLE moz_cookies(
@@ -93,77 +45,74 @@ func (s *CookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.Cookie, err
 			)
 		*/
 
+		cookie := kooky.Cookie{}
+		var err error
+
 		// Name
-		cookie.Name, ok = rec.Values[columnIDs[`name`]].(string)
-		if !ok {
-			return fmt.Errorf("got unexpected value for Name %v (type %[1]T)", rec.Values[columnIDs[`name`]])
+		cookie.Name, err = row.String(`name`)
+		if err != nil {
+			return err
 		}
 
 		// Value
-		cookie.Value, ok = rec.Values[columnIDs[`value`]].(string)
-		if !ok {
-			return fmt.Errorf("got unexpected value for Value %v (type %[1]T)", rec.Values[columnIDs[`value`]])
+		cookie.Value, err = row.String(`value`)
+		if err != nil {
+			return err
 		}
 
 		// Domain
-		if baseDomainRemoved {
-			if host, ok := rec.Values[columnIDs[`host`]].(string); ok {
-				cookie.Domain = domainutil.Domain(host)
+		if baseDomain := row.ValueOrFallback(`baseDomain`, nil); baseDomain == nil {
+			if host, err := row.String(`host`); err != nil {
+				return err
 			} else {
-				return fmt.Errorf("got unexpected value for Host %v (type %[1]T)", rec.Values[columnIDs[`host`]])
+				cookie.Domain = domainutil.Domain(host)
 			}
 		} else {
 			// handle databases prior v78 ESR
-			cookie.Domain, ok = rec.Values[columnIDs[`baseDomain`]].(string)
+			var ok bool
+			cookie.Domain, ok = baseDomain.(string)
 			if !ok {
-				return fmt.Errorf("got unexpected value for Domain %v (type %[1]T)", rec.Values[columnIDs[`baseDomain`]])
+				return fmt.Errorf("got unexpected value for baseDomain %v (type %[1]T)", baseDomain)
 			}
 		}
 
 		// Path
-		cookie.Path, ok = rec.Values[columnIDs[`path`]].(string)
-		if !ok {
-			return fmt.Errorf("got unexpected value for Path %v (type %[1]T)", rec.Values[columnIDs[`path`]])
+		cookie.Path, err = row.String(`path`)
+		if err != nil {
+			return err
 		}
 
 		// Expires
-		{
-			expiry := rec.Values[columnIDs[`expiry`]]
-			if int32Value, ok := expiry.(int32); ok {
-				cookie.Expires = time.Unix(int64(int32Value), 0)
-			} else if uint64Value, ok := expiry.(uint64); ok {
-				cookie.Expires = time.Unix(int64(uint64Value), 0)
-			} else {
-				return fmt.Errorf("got unexpected value for Expires %v (type %[1]T)", expiry)
-			}
+		if expiry, err := row.Int64(`expiry`); err == nil {
+			cookie.Expires = time.Unix(expiry, 0)
+		} else {
+			return err
 		}
 
 		// Creation
-		int64Value, ok := rec.Values[columnIDs[`creationTime`]].(int64)
-		if !ok {
-			return fmt.Errorf("got unexpected value for Creation %v (type %[1]T)", rec.Values[columnIDs[`creationTime`]])
+		if creationTime, err := row.Int64(`creationTime`); err == nil {
+			cookie.Creation = time.Unix(creationTime/1e6, 0) // drop nanoseconds
+		} else {
+			return err
 		}
-		cookie.Creation = time.Unix(int64Value/1e6, 0) // drop nanoseconds
 
 		// Secure
-		intValue, ok := rec.Values[columnIDs[`isSecure`]].(int)
-		if !ok {
-			return fmt.Errorf("got unexpected value for Secure %v (type %[1]T)", rec.Values[columnIDs[`isSecure`]])
+		if isSecure, err := row.Int(`isSecure`); err == nil {
+			cookie.Secure = isSecure > 0
+		} else {
+			return err
 		}
-		cookie.Secure = intValue > 0
 
 		// HttpOnly
-		intValue, ok = rec.Values[columnIDs[`isHttpOnly`]].(int)
-		if !ok {
-			return fmt.Errorf("got unexpected value for HttpOnly %v (type %[1]T)", rec.Values[columnIDs[`isHttpOnly`]])
-		}
-		cookie.HttpOnly = intValue > 0
-
-		if !kooky.FilterCookie(&cookie, filters...) {
-			return nil
+		if isHttpOnly, err := row.Int(`isHttpOnly`); err == nil {
+			cookie.HttpOnly = isHttpOnly > 0
+		} else {
+			return err
 		}
 
-		cookies = append(cookies, &cookie)
+		if kooky.FilterCookie(&cookie, filters...) {
+			cookies = append(cookies, &cookie)
+		}
 
 		return nil
 	})

--- a/internal/utils/tablerow.go
+++ b/internal/utils/tablerow.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/go-sqlite/sqlite3"
+)
+
+type TableRow struct {
+	columns map[string]int
+	record  *sqlite3.Record
+}
+
+func (row TableRow) BlobOrFallback(columnName string, fallback []byte) ([]byte, error) {
+	rawValue := row.ValueOrFallback(columnName, nil)
+	if value, ok := rawValue.([]byte); ok {
+		return value, nil
+	}
+	return nil, fmt.Errorf("expected column [%s] to be []byte; got %T with value %[2]v", columnName, rawValue)
+}
+
+func (row TableRow) Byte(columnName string) (byte, error) {
+	rawValue, err := row.Value(columnName)
+	if err != nil {
+		return 0, nil
+	}
+	if value, ok := rawValue.(byte); ok {
+		return value, nil
+	}
+	return 0, fmt.Errorf("expected column [%s] to be byte; got %T with value %[2]v", columnName, rawValue)
+}
+
+func (row TableRow) Int(columnName string) (int, error) {
+	rawValue, err := row.Value(columnName)
+	if err != nil {
+		return 0, nil
+	}
+	if value, ok := rawValue.(int); ok {
+		return value, nil
+	}
+	return 0, fmt.Errorf("expected column [%s] to be int; got %T with value %[2]v", columnName, rawValue)
+}
+
+func (row TableRow) Int64(columnName string) (int64, error) {
+	rawValue, err := row.Value(columnName)
+	if err != nil {
+		return 0, err
+	}
+	switch value := rawValue.(type) {
+	case int64:
+		return value, nil
+	case int32:
+		return int64(value), nil
+	case int:
+		return int64(value), nil
+	default:
+		return 0, fmt.Errorf("expected column [%s] to be int64; got %T with value %[2]v", columnName, rawValue)
+	}
+}
+
+func (row TableRow) String(columnName string) (string, error) {
+	rawValue, err := row.Value(columnName)
+	if err != nil {
+		return "", err
+	}
+	if value, ok := rawValue.(string); ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("expected column [%s] to be string; got %T with value %[2]v", columnName, rawValue)
+}
+
+func (row TableRow) Value(columnName string) (interface{}, error) {
+	if index, ok := row.columns[columnName]; !ok {
+		return nil, fmt.Errorf("table doesn't have a column named [%s]", columnName)
+	} else if count := len(row.columns); count <= index {
+		return nil, fmt.Errorf("column named [%s] has index %d but row only has %d values", columnName, index, count)
+	} else {
+		return row.record.Values[index], nil
+	}
+}
+
+func (row TableRow) ValueOrFallback(columnName string, fallback interface{}) interface{} {
+	if index, ok := row.columns[columnName]; ok && index < len(row.columns) {
+		return row.record.Values[index]
+	}
+	return fallback
+}

--- a/internal/utils/tablerow.go
+++ b/internal/utils/tablerow.go
@@ -19,26 +19,12 @@ func (row TableRow) BlobOrFallback(columnName string, fallback []byte) ([]byte, 
 	return nil, fmt.Errorf("expected column [%s] to be []byte; got %T with value %[2]v", columnName, rawValue)
 }
 
-func (row TableRow) Byte(columnName string) (byte, error) {
+func (row TableRow) Bool(columnName string) (bool, error) {
 	rawValue, err := row.Value(columnName)
 	if err != nil {
-		return 0, nil
+		return false, err
 	}
-	if value, ok := rawValue.(byte); ok {
-		return value, nil
-	}
-	return 0, fmt.Errorf("expected column [%s] to be byte; got %T with value %[2]v", columnName, rawValue)
-}
-
-func (row TableRow) Int(columnName string) (int, error) {
-	rawValue, err := row.Value(columnName)
-	if err != nil {
-		return 0, nil
-	}
-	if value, ok := rawValue.(int); ok {
-		return value, nil
-	}
-	return 0, fmt.Errorf("expected column [%s] to be int; got %T with value %[2]v", columnName, rawValue)
+	return rawValue != 0, nil
 }
 
 func (row TableRow) Int64(columnName string) (int64, error) {
@@ -49,6 +35,11 @@ func (row TableRow) Int64(columnName string) (int64, error) {
 	switch value := rawValue.(type) {
 	case int64:
 		return value, nil
+	case uint64:
+		if int64(value) < 0 {
+			return 0, fmt.Errorf("expected column [%s] to be int64; got uint64 value that can't fit in int64: %d", columnName, rawValue)
+		}
+		return int64(value), nil
 	case int32:
 		return int64(value), nil
 	case int:

--- a/internal/utils/visittablerows.go
+++ b/internal/utils/visittablerows.go
@@ -6,12 +6,16 @@ import (
 	"github.com/go-sqlite/sqlite3"
 )
 
-func VisitTableRows(db *sqlite3.DbFile, tableName string, f func(rowID *int64, row TableRow) error) error {
+func VisitTableRows(db *sqlite3.DbFile, tableName string, columnNameMappings map[string]string, f func(rowID *int64, row TableRow) error) error {
 	columns := make(map[string]int)
 	if table, ok := findTable(db, tableName); ok {
 		for index, column := range table.Columns() {
-			if _, ok := columns[column.Name()]; !ok {
-				columns[column.Name()] = index
+			columnName := column.Name()
+			if mappedColumnName, ok := columnNameMappings[columnName]; ok {
+				columnName = mappedColumnName
+			}
+			if _, ok := columns[columnName]; !ok {
+				columns[columnName] = index
 			}
 		}
 	} else {

--- a/internal/utils/visittablerows.go
+++ b/internal/utils/visittablerows.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/go-sqlite/sqlite3"
+)
+
+func VisitTableRows(db *sqlite3.DbFile, tableName string, f func(rowID *int64, row TableRow) error) error {
+	columns := make(map[string]int)
+	if table, ok := findTable(db, tableName); ok {
+		for index, column := range table.Columns() {
+			if _, ok := columns[column.Name()]; !ok {
+				columns[column.Name()] = index
+			}
+		}
+	} else {
+		return fmt.Errorf("Unable to find table named [%s] in %v", tableName, db)
+	}
+	return db.VisitTableRecords(tableName, func(rowID *int64, record sqlite3.Record) error {
+		return f(rowID, TableRow{columns, &record})
+	})
+}
+
+func findTable(db *sqlite3.DbFile, tableName string) (sqlite3.Table, bool) {
+	for _, table := range db.Tables() {
+		if table.Name() == tableName {
+			return table, true
+		}
+	}
+	return sqlite3.Table{}, false
+}


### PR DESCRIPTION
The hardcoded column numbers were magical and unnecessary, and the row length checks were brittle and unnecessary.

This PR introduces a `TableRow` abstraction that provides methods for reading column values that give descriptive error messages if a required column is missing or doesn't have a value in a particular row. It then provides a small `VisitTableRows` function that serves as a richer equivalent to the `VisitTableRecords` method from go-sqlite. The `ReadCookies` methods for chrome and firefox are reworked in terms of these abstractions.

This PR is a follow-on or alternative to #42. I couldn't fall asleep after writing #42 because my mind kept coming back to those length checks, so I got up and did this.