### PR TITLE
Fix chromium and opera

### DIFF
--- a/browser/chromium/chromium.go
+++ b/browser/chromium/chromium.go
@@ -1,4 +1,4 @@
-package chrome
+package chromium
 
 import (
 	"net/http"

--- a/browser/chromium/find.go
+++ b/browser/chromium/find.go
@@ -1,4 +1,4 @@
-package chrome
+package chromium
 
 import (
 	"github.com/zellyn/kooky"

--- a/browser/opera/cookies4dat.go
+++ b/browser/opera/cookies4dat.go
@@ -57,7 +57,8 @@ func (s *operaPrestoCookieStore) ReadCookies(filters ...kooky.Filter) ([]*kooky.
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	return p.cookies, nil
+	cookies := kooky.FilterCookies(p.cookies, filters...)
+	return cookies, nil
 }
 
 type processor struct {


### PR DESCRIPTION
I noticed 2 errors that my last PR introduced:

- fix package name after chromium package split off
- opera package ignored filters for old presto cookies